### PR TITLE
actor-paths-build: fix the incorrect actor-name

### DIFF
--- a/actor-paths/src/main/scala/App.scala
+++ b/actor-paths/src/main/scala/App.scala
@@ -15,8 +15,8 @@ object ActorPath extends App {
   counter1 ! PoisonPill
   Thread.sleep(100)
 
-  val counter2 = system.actorOf(Props[Counter], "counter")
-  println(s"Actor Reference for counter1: $counter2")
+  val counter2 = system.actorOf(Props[Counter], "Counter")
+  println(s"Actor Reference for counter2: $counter2")
 
   val counterSelection2 = system.actorSelection("counter")
   println(s"Actor Selection for counter2: $counterSelection2")


### PR DESCRIPTION
Awesome repository ! 
Just a little fix. 
I think the `counter2`'s actor-name should be same as `counter1`'s actor-name.
